### PR TITLE
Fix for file path

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,8 +2,9 @@ import wideq
 import json
 import time
 import argparse
+import os
 
-STATE_FILE = 'wideq_state.json'
+STATE_FILE = os.path.join(os.path.dirname(__file__), 'wideq_state.json')
 
 
 def authenticate(gateway):


### PR DESCRIPTION
Hi!

When I start python script example.py outside directory where it is, file wideq_state.json will be created in directory where I am.

But I think, it'll be good when file wideq_state.json will be created near file example.py.