### PR TITLE
Don't stop monitoring work immediately

### DIFF
--- a/wideq/core.py
+++ b/wideq/core.py
@@ -335,6 +335,10 @@ class Session(object):
         work_list = [{'deviceId': device_id, 'workId': work_id}]
         res = self.post('rti/rtiResult', {'workList': work_list})['workList']
 
+        # Return None in case work hasn't started yet
+        if not 'returnCode' in res:
+            return None
+
         # Check for errors.
         code = res.get('returnCode')  # returnCode can be missing.
         if code != '0000':


### PR DESCRIPTION
Hi,
I noticed that it takes a bit for my monitoring work to start reporting status.
The existing error handling method stops the monitoring job right away, which is not ideal.
This PR makes the monitor try fetching its status a few times before creating a new unit of work.

thanks for creating this library!