### PR TITLE
Test Gateway instantiation and remove gateway_info

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,24 +1,55 @@
 import unittest
 import responses
-import json
 
 import wideq.core
 
 
 class SimpleTest(unittest.TestCase):
     @responses.activate
-    def test_gateway_info(self):
+    def test_gateway_en_US(self):
         responses.add(
             responses.POST,
             'https://kic.lgthinq.com:46030/api/common/gatewayUriList',
-            json={'lgedmRoot': 'foo'},
+            json={
+                'lgedmRoot': {
+                    "thinqUri": "https://aic.lgthinq.com:46030/api",
+                    "empUri": "https://us.m.lgaccount.com",
+                    "oauthUri": "https://us.lgeapi.com",
+                    "countryCode": "US",
+                    "langCode": "en-US",
+                }
+            }
         )
-
-        data = wideq.core.gateway_info('COUNTRY', 'LANGUAGE')
-        self.assertEqual(data, 'foo')
-
+        gatewayInstance = wideq.core.Gateway.discover('US', 'en-US')
         self.assertEqual(len(responses.calls), 1)
-        self.assertEqual(
-            json.loads(responses.calls[0].request.body),
-            {'lgedmRoot': {'countryCode': 'COUNTRY', 'langCode': 'LANGUAGE'}},
+        self.assertEqual(gatewayInstance.country, 'US')
+        self.assertEqual(gatewayInstance.language, 'en-US')
+        self.assertEqual(gatewayInstance.auth_base,
+                         'https://us.m.lgaccount.com')
+        self.assertEqual(gatewayInstance.api_root,
+                         'https://aic.lgthinq.com:46030/api')
+        self.assertEqual(gatewayInstance.oauth_root, 'https://us.lgeapi.com')
+
+    @responses.activate
+    def test_gateway_en_NO(self):
+        responses.add(
+            responses.POST,
+            'https://kic.lgthinq.com:46030/api/common/gatewayUriList',
+            json={
+                'lgedmRoot': {
+                  "countryCode": "NO", "langCode": "en-NO",
+                  "thinqUri": "https://eic.lgthinq.com:46030/api",
+                  "empUri": "https://no.m.lgaccount.com",
+                  "oauthUri": "https://no.lgeapi.com",
+                }
+            }
         )
+        gatewayInstance = wideq.core.Gateway.discover('NO', 'en-NO')
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(gatewayInstance.country, 'NO')
+        self.assertEqual(gatewayInstance.language, 'en-NO')
+        self.assertEqual(gatewayInstance.auth_base,
+                         'https://no.m.lgaccount.com')
+        self.assertEqual(gatewayInstance.api_root,
+                         'https://eic.lgthinq.com:46030/api')
+        self.assertEqual(gatewayInstance.oauth_root, 'https://no.lgeapi.com')

--- a/wideq/core.py
+++ b/wideq/core.py
@@ -146,19 +146,6 @@ def lgedm_post(url, data=None, access_token=None, session_id=None):
     return out
 
 
-def gateway_info(country, language):
-    """Load information about the hosts to use for API interaction.
-
-    `country` and `language` are codes, like "US" and "en-US,"
-    respectively.
-    """
-
-    return lgedm_post(
-        GATEWAY_URL,
-        {'countryCode': country, 'langCode': language},
-    )
-
-
 def oauth_url(auth_base, country, language):
     """Construct the URL for users to log in (in a browser) to start an
     authenticated session.
@@ -253,7 +240,13 @@ class Gateway(object):
 
     @classmethod
     def discover(cls, country, language) -> 'Gateway':
-        gw = gateway_info(country, language)
+        """Load information about the hosts to use for API interaction.
+
+        `country` and `language` are codes, like "US" and "en-US,"
+        respectively.
+        """
+        gw = lgedm_post(GATEWAY_URL,
+                        {'countryCode': country, 'langCode': language})
         return cls(gw['empUri'], gw['thinqUri'], gw['oauthUri'],
                    country, language)
 


### PR DESCRIPTION
The function just forwarded to do one API call, do the same call inline
and improve testing at the same time by checking that 'Gateway' gets
instantiated correctly.