### PR TITLE
Allow strings in ModelInfo

### DIFF
--- a/example.py
+++ b/example.py
@@ -233,14 +233,14 @@ def main() -> None:
     args = parser.parse_args()
     country_regex = re.compile(r"^[A-Z]{2,3}$")
     if not country_regex.match(args.country):
-        print("Error: Country must be two or three letters" \
+        print("Error: Country must be two or three letters"
               f" all upper case (e.g. US, NO, KR) got: '{args.country}'",
               file=sys.stderr)
         exit(1)
     language_regex = re.compile(r"^[a-z]{2,3}-[A-Z]{2,3}$")
     if not language_regex.match(args.language):
-        print("Error: Language must be a combination of language" \
-              " and country (e.g. en-US, no-NO, kr-KR)" \
+        print("Error: Language must be a combination of language"
+              " and country (e.g. en-US, no-NO, kr-KR)"
               f" got: '{args.language}'",
               file=sys.stderr)
         exit(1)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 import unittest
 
 from wideq.client import (
-    BitValue, EnumValue, ModelInfo, RangeValue, ReferenceValue)
+    BitValue, EnumValue, ModelInfo, RangeValue, ReferenceValue, StringValue)
 
 
 DATA = {
@@ -66,10 +66,15 @@ DATA = {
             ],
             'type': 'Bit'
         },
+        'TimeBsOn': {
+            '_comment':
+                '오전 12시 30분은 0030, 오후12시30분은 1230 ,오후 4시30분은 1630 off는 0 ',
+            'type': 'String'
+        },
         'Unexpected': {'type': 'Unexpected'},
-        'StringOption': {
-            'type': 'String',
-            'option': 'some string'
+        'Unexpected2': {
+            'type': 'Unexpected',
+            'option': 'some option'
         },
     },
     'Course': {
@@ -120,6 +125,12 @@ class ModelInfoTest(unittest.TestCase):
         expected = ReferenceValue(DATA['Course'])
         self.assertEqual(expected, actual)
 
+    def test_string(self):
+        actual = self.model_info.value('TimeBsOn')
+        expected = StringValue(
+            "오전 12시 30분은 0030, 오후12시30분은 1230 ,오후 4시30분은 1630 off는 0 ")
+        self.assertEqual(expected, actual)
+
     def test_value_unsupported(self):
         data = "{'type': 'Unexpected'}"
         with self.assertRaisesRegex(
@@ -129,9 +140,9 @@ class ModelInfoTest(unittest.TestCase):
             self.model_info.value('Unexpected')
 
     def test_value_unsupported_but_data_available(self):
-        data = "{'type': 'String', 'option': 'some string'}"
+        data = "{'type': 'Unexpected', 'option': 'some option'}"
         with self.assertRaisesRegex(
                 ValueError,
-                f"unsupported value name: 'StringOption'"
-                f" type: 'String' data: '{data}"):
-            self.model_info.value('StringOption')
+                f"unsupported value name: 'Unexpected2'"
+                f" type: 'Unexpected' data: '{data}"):
+            self.model_info.value('Unexpected2')

--- a/wideq/client.py
+++ b/wideq/client.py
@@ -308,6 +308,7 @@ RangeValue = namedtuple('RangeValue', ['min', 'max', 'step'])
 #: This is a value that is a reference to another key in the data that is at
 #: the same level as the `Value` key.
 ReferenceValue = namedtuple('ReferenceValue', ['reference'])
+StringValue = namedtuple('StringValue', ['comment'])
 
 
 class ModelInfo(object):
@@ -322,7 +323,7 @@ class ModelInfo(object):
 
         :param name: The name to look up.
         :returns: One of (`BitValue`, `EnumValue`, `RangeValue`,
-            `ReferenceValue`).
+            `ReferenceValue`, `StringValue`).
         :raises ValueError: If an unsupported type is encountered.
         """
         d = self.data['Value'][name]
@@ -339,6 +340,8 @@ class ModelInfo(object):
         elif d['type'].lower() == 'reference':
             ref = d['option'][0]
             return ReferenceValue(self.data[ref])
+        elif d['type'].lower() == 'string':
+            return StringValue(d.get('_comment', ''))
         else:
             raise ValueError(
                 f"unsupported value name: '{name}'"


### PR DESCRIPTION
The only instance where this is used is a comment,
see issue #62. For now it will just be ignored. The comment seems to
contain several times.

Fixes #62