### PR TITLE
avoid crashing if DisplayControl is not supported

### DIFF
--- a/wideq/ac.py
+++ b/wideq/ac.py
@@ -268,7 +268,7 @@ class ACDevice(Device):
             value = self._get_control('DisplayControl')
             return value == '0'  # Seems backwards, but isn't.
         except FailedRequestError:
-            # Device does not support reporting display light status
+            # Device does not support reporting display light status.
             # Since it's probably not changable the it must be on
             return True
 

--- a/wideq/ac.py
+++ b/wideq/ac.py
@@ -268,7 +268,9 @@ class ACDevice(Device):
             value = self._get_control('DisplayControl')
             return value == '0'  # Seems backwards, but isn't.
         except FailedRequestError:
-            return True  # Device does not support reporting display light status (so it must be on)
+            # Device does not support reporting display light status
+            # Since it's probably not changablem the it must be on
+            return True  
 
     def get_volume(self):
         """Get the speaker volume level."""

--- a/wideq/ac.py
+++ b/wideq/ac.py
@@ -269,7 +269,7 @@ class ACDevice(Device):
             return value == '0'  # Seems backwards, but isn't.
         except FailedRequestError:
             # Device does not support reporting display light status.
-            # Since it's probably not changable the it must be on
+            # Since it's probably not changeable the it must be on.
             return True
 
     def get_volume(self):

--- a/wideq/ac.py
+++ b/wideq/ac.py
@@ -264,8 +264,11 @@ class ACDevice(Device):
     def get_light(self):
         """Get a Boolean indicating whether the display light is on."""
 
-        value = self._get_control('DisplayControl')
-        return value == '0'  # Seems backwards, but isn't.
+        try:
+            value = self._get_control('DisplayControl')
+            return value == '0'  # Seems backwards, but isn't.
+        except FailedRequestError:
+            return 0  # Device does not support reporting display light status
 
     def get_volume(self):
         """Get the speaker volume level."""

--- a/wideq/ac.py
+++ b/wideq/ac.py
@@ -269,8 +269,8 @@ class ACDevice(Device):
             return value == '0'  # Seems backwards, but isn't.
         except FailedRequestError:
             # Device does not support reporting display light status
-            # Since it's probably not changablem the it must be on
-            return True  
+            # Since it's probably not changable the it must be on
+            return True
 
     def get_volume(self):
         """Get the speaker volume level."""

--- a/wideq/ac.py
+++ b/wideq/ac.py
@@ -268,7 +268,7 @@ class ACDevice(Device):
             value = self._get_control('DisplayControl')
             return value == '0'  # Seems backwards, but isn't.
         except FailedRequestError:
-            return 0  # Device does not support reporting display light status
+            return True  # Device does not support reporting display light status (so it must be on)
 
     def get_volume(self):
         """Get the speaker volume level."""


### PR DESCRIPTION
This should address #19 in the cases where the unit has no support for obtaining the display light status (DisplayControl). Is based on the same fix that was made previously for when the unit has not Speaker support. 