### PR TITLE
Request supported Operations from model info

### DIFF
--- a/example.py
+++ b/example.py
@@ -146,6 +146,8 @@ def turn(client, device_id, on_off):
 
 def ac_config(client, device_id):
     ac = wideq.ACDevice(client, _force_device(client, device_id))
+    print(ac.supported_operations)
+    print(ac.supported_on_operation)
     print(ac.get_filter_state())
     print(ac.get_mfilter_state())
     print(ac.get_energy_target())

--- a/wideq/ac.py
+++ b/wideq/ac.py
@@ -154,6 +154,45 @@ class ACDevice(Device):
             out[c_num] = f
         return out
 
+    @property
+    def supported_operations(self):
+        """Get a list of the ACOp Operations the device supports.
+        """
+
+        mapping = self.model.value('Operation').options
+        return [ACOp(o) for i, o in mapping.items()]
+
+    @property
+    def supported_on_operation(self):
+        """Get the most correct "On" operation the device supports.
+        :raises ValueError: If ALL_ON is not supported, but there are
+            multiple supported ON operations. If a model raises this,
+            its behaviour needs to be determined so this function can
+            make a better decision.
+        """
+
+        operations = self.supported_operations
+        operations.remove(ACOp.OFF)
+
+        # This ON operation appears to be supported in newer AC models
+        if ACOp.ALL_ON in operations:
+            return ACOp.ALL_ON
+
+        # Older models, or possibly just the LP1419IVSM, do not support ALL_ON,
+        # instead advertising only a single operation of RIGHT_ON.
+        # Thus, if there's only one ON operation, we use that.
+        if len(operations) == 1:
+            return operations[0]
+
+        # Hypothetically, the API could return multiple ON operations, neither
+        # of which are ALL_ON. This will raise in that case, as we don't know
+        # what that model will expect us to do to turn everything on.
+        # Or, this code will never actually be reached! We can only hope. :)
+        raise ValueError(
+            f"could not determine correct 'on' operation:"
+            f" too many reported operations: '{str(operations)}'")
+
+
     def set_celsius(self, c):
         """Set the device's target temperature in Celsius degrees.
         """
@@ -229,7 +268,7 @@ class ACDevice(Device):
         """Turn on or off the device (according to a boolean).
         """
 
-        op = ACOp.ALL_ON if is_on else ACOp.OFF
+        op = self.supported_on_operation if is_on else ACOp.OFF
         op_value = self.model.enum_value('Operation', op.value)
         self._set_control('Operation', op_value)
 

--- a/wideq/ac.py
+++ b/wideq/ac.py
@@ -192,7 +192,6 @@ class ACDevice(Device):
             f"could not determine correct 'on' operation:"
             f" too many reported operations: '{str(operations)}'")
 
-
     def set_celsius(self, c):
         """Set the device's target temperature in Celsius degrees.
         """


### PR DESCRIPTION
This fixes #83 (and then hopefully sampsyo/hass-smartthinq#45) - I have the same LP1419IVSM Air Conditioner model, and it causes an error when turning on using `wideq`.

I've updated the `ACDevice` class with two new `@properties`, which are the list of Operations the device supports, and the best-supported ON operation from that list.

This makes the presumption that if the model reports `ALL_ON` as available, that it is appropriate to use (as the existing code did), but if `ALL_ON` is not supported by the particular model, it will fall back to using whichever `ON` Operation it reports as supporting. In the case of the LP1419, that will be `RIGHT_ON` 🤘🏼.

Additionally, as a backstop, this will raise an error if `ALL_ON` is not supported but there are still more than one supported `ON` operation - from reading issues I haven't been able to find any evidence that such a device exists, but if one should pop up it'll likely need handling in some creative way.

These new values are now also reported in the `ac-config` subcommand of `example.py`.

Finally, this updates the `set_on` method to use the resultant operation name. This now means that `example.py set [id] on` works for my air conditioner again, and just in time for the warmer weather! ☀️

I haven’t made any attempt to cache these values, as it appears trivial to retrieve them, and it looks like the model information itself is already cached.