### PR TITLE
Update README.md to reflect v2 incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 WideQ
 =====
 
-:warning: **New users of LG SmartThinq**: This library only works with v1 of the LG SmartThinq API. Work is currently underway to support the v2 API. If you recently created a LG SmartThinq account, this library will likely return 0 devices when you execute the `ls` command.
+:warning: **New users of LG SmartThinq**: This library only works with v1 of the LG SmartThinq API. Work is currently underway to support the v2 API, and the discussion can be found [here](https://github.com/sampsyo/wideq/pull/100). If you recently created a LG SmartThinq account, this library will likely return 0 devices when you execute the `ls` command.
 
 A library for interacting with the "LG SmartThinq" system, which can control heat pumps and such. I reverse-engineered the API from their mobile app.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 WideQ
 =====
 
+:warning: **New users of LG SmartThinq**: This library only works with v1 of the LG SmartThinq API. Work is currently underway to support the v2 API. If you recently created a LG SmartThinq account, this library will likely return 0 devices when you execute the `ls` command.
+
 A library for interacting with the "LG SmartThinq" system, which can control heat pumps and such. I reverse-engineered the API from their mobile app.
 
 To try out the API, there is a simple command-line tool included here, called `example.py`.


### PR DESCRIPTION
Hi @sampsyo! 

Thanks for the work on the SmartThinq API. The library doesn't seem to currently work on the v2 API, and until it does, I suggest this small change to the readme so that people aren't creating issues or are confused as to why it doesn't work for them. I was confused for a little bit until I went through the issue tracker to figure out why I wasn't getting any devices.

Of course, happy to help get v2 on track.