### PR TITLE
Ensure name is always string

### DIFF
--- a/wideq/client.py
+++ b/wideq/client.py
@@ -293,7 +293,7 @@ class DeviceInfo(object):
 
     @property
     def name(self) -> str:
-        return self.data['alias']
+        return str(self.data['alias'])
 
     @property
     def type(self) -> DeviceType:


### PR DESCRIPTION
Always convert device name (alias) to string. Solves issues e.g. when you use number as device alias (see sampsyo/hass-smartthinq#90).